### PR TITLE
Licensing Update

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,10 @@
 BSD 3-Clause License
 
-Copyright (c) 2017, Hadi Esiely
+Copyright (c) 2017, Ewan Mellor, Rolf Widenfelt, JD Zamifirescu
+
+Changes authored by Hadi Esiely:
+Copyright 2018 The Johns Hopkins University Applied Physics Laboratory LLC.
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/holonet-web/app.py
+++ b/holonet-web/app.py
@@ -1,6 +1,9 @@
 '''
 
-Copyright 2017 Hadi Esiely
+Copyright 2017 Ewan Mellor
+
+Changes authored by Hadi Esiely:
+Copyright 2018 The Johns Hopkins University Applied Physics Laboratory LLC.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/holonet-web/holonet-web.sh
+++ b/holonet-web/holonet-web.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-# Copyright 2017 Hadi Esiely
+# Copyright 2017 Ewan Mellor
+#
+# Changes authored by Hadi Esiely:
+# Copyright 2018 The Johns Hopkins University Applied Physics Laboratory LLC.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/holonet-web/holonet/holonetGPIO.py
+++ b/holonet-web/holonet/holonetGPIO.py
@@ -1,6 +1,9 @@
 '''
 
-Copyright 2017 Hadi Esiely
+Copyright 2017 Ewan Mellor
+
+Changes authored by Hadi Esiely:
+Copyright 2018 The Johns Hopkins University Applied Physics Laboratory LLC.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/holonet-web/holonet/mailboxes.py
+++ b/holonet-web/holonet/mailboxes.py
@@ -1,6 +1,9 @@
 '''
 
-Copyright 2017 Hadi Esiely
+Copyright 2017 Ewan Mellor
+
+Changes authored by Hadi Esiely:
+Copyright 2018 The Johns Hopkins University Applied Physics Laboratory LLC.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/holonet-web/holonet/message.py
+++ b/holonet-web/holonet/message.py
@@ -1,6 +1,9 @@
 '''
 
-Copyright 2017 Hadi Esiely
+Copyright 2017 Ewan Mellor
+
+Changes authored by Hadi Esiely:
+Copyright 2018 The Johns Hopkins University Applied Physics Laboratory LLC.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/holonet-web/holonet/mockGPIO.py
+++ b/holonet-web/holonet/mockGPIO.py
@@ -1,6 +1,9 @@
 '''
 
-Copyright 2017 Hadi Esiely
+Copyright 2017 Ewan Mellor
+
+Changes authored by Hadi Esiely:
+Copyright 2018 The Johns Hopkins University Applied Physics Laboratory LLC.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/holonet-web/holonet/queue_manager.py
+++ b/holonet-web/holonet/queue_manager.py
@@ -1,6 +1,9 @@
 '''
 
-Copyright 2017 Hadi Esiely
+Copyright 2017 Ewan Mellor
+
+Changes authored by Hadi Esiely:
+Copyright 2018 The Johns Hopkins University Applied Physics Laboratory LLC.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/holonet-web/holonet/rockblock.py
+++ b/holonet-web/holonet/rockblock.py
@@ -12,8 +12,15 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
-#   Copyright 2017 Hadi Esiely
-#   All changes made
+'''
+All changes made
+
+Copyright 2017 Ewan Mellor, Rolf Widenfelt
+
+Changes authored by Hadi Esiely:
+Copyright 2018 The Johns Hopkins University Applied Physics Laboratory LLC.
+'''
+
 
 
 import glob

--- a/holonet-web/holonet/system_manager.py
+++ b/holonet-web/holonet/system_manager.py
@@ -1,6 +1,9 @@
 '''
 
-Copyright 2017 Hadi Esiely
+Copyright 2017 Ewan Mellor
+
+Changes authored by Hadi Esiely:
+Copyright 2018 The Johns Hopkins University Applied Physics Laboratory LLC.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/holonet-web/holonet/utils.py
+++ b/holonet-web/holonet/utils.py
@@ -1,6 +1,9 @@
 '''
 
-Copyright 2017 Hadi Esiely
+Copyright 2017 Ewan Mellor
+
+Changes authored by Hadi Esiely:
+Copyright 2018 The Johns Hopkins University Applied Physics Laboratory LLC.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/holonet-web/holonet/version.py
+++ b/holonet-web/holonet/version.py
@@ -1,6 +1,9 @@
 '''
 
-Copyright 2017 Hadi Esiely
+Copyright 2017 Ewan Mellor
+
+Changes authored by Hadi Esiely:
+Copyright 2018 The Johns Hopkins University Applied Physics Laboratory LLC.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/holonet-web/setup.py
+++ b/holonet-web/setup.py
@@ -1,6 +1,9 @@
 '''
 
-Copyright 2017 Hadi Esiely
+Copyright 2017 Ewan Mellor
+
+Changes authored by Hadi Esiely:
+Copyright 2018 The Johns Hopkins University Applied Physics Laboratory LLC.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/holonet-web/templates/base.html
+++ b/holonet-web/templates/base.html
@@ -1,6 +1,9 @@
 <!--
 
-Copyright 2017 Hadi Esiely
+Copyright 2017 Ewan Mellor
+
+Changes authored by Hadi Esiely:
+Copyright 2018 The Johns Hopkins University Applied Physics Laboratory LLC.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/holonet-web/templates/index.html
+++ b/holonet-web/templates/index.html
@@ -1,6 +1,9 @@
 <!--
 
-Copyright 2017 Hadi Esiely
+Copyright 2017 Ewan Mellor
+
+Changes authored by Hadi Esiely:
+Copyright 2018 The Johns Hopkins University Applied Physics Laboratory LLC.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/holonet-web/templates/system.html
+++ b/holonet-web/templates/system.html
@@ -1,6 +1,9 @@
 <!--
 
-Copyright 2017 Hadi Esiely
+Copyright 2017 Ewan Mellor
+
+Changes authored by Hadi Esiely:
+Copyright 2018 The Johns Hopkins University Applied Physics Laboratory LLC.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/holonet-web/templates/test.html
+++ b/holonet-web/templates/test.html
@@ -1,6 +1,9 @@
 <!--
 
-Copyright 2017 Hadi Esiely
+Copyright 2017 Ewan Mellor
+
+Changes authored by Hadi Esiely:
+Copyright 2018 The Johns Hopkins University Applied Physics Laboratory LLC.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/holonet-web/templates/thread.html
+++ b/holonet-web/templates/thread.html
@@ -1,6 +1,9 @@
 <!--
 
-Copyright 2017 Hadi Esiely
+Copyright 2017 Ewan Mellor
+
+Changes authored by Hadi Esiely:
+Copyright 2018 The Johns Hopkins University Applied Physics Laboratory LLC.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/holonet-web/webpack.config.js
+++ b/holonet-web/webpack.config.js
@@ -1,6 +1,9 @@
 /*
 
-Copyright 2017 Hadi Esiely
+Copyright 2017 Ewan Mellor
+
+Changes authored by Hadi Esiely:
+Copyright 2018 The Johns Hopkins University Applied Physics Laboratory LLC.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/iridium-to-twilio/holonet-handler.yaml
+++ b/iridium-to-twilio/holonet-handler.yaml
@@ -1,30 +1,33 @@
-#Copyright 2017 Hadi Esiely
+# Copyright 2017 Ewan Mellor, JD Zamifirescu
 #
-#Redistribution and use in source and binary forms, with or without
-#modification, are permitted provided that the following conditions are met:
+# Changes authored by Hadi Esiely:
+# Copyright 2018 The Johns Hopkins University Applied Physics Laboratory LLC.
 #
-#1. Redistributions of source code must retain the above copyright notice,
-#this list of conditions and the following disclaimer.
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
 #
-#2. Redistributions in binary form must reproduce the above copyright notice,
-#this list of conditions and the following disclaimer in the documentation
-#and/or other materials provided with the distribution.
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
 #
-#3. Neither the name of the copyright holder nor the names of its
-#contributors may be used to endorse or promote products derived from this
-#software without specific prior written permission.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
 #
-#THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-#AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-#IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-#ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-#LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-#CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-#SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
-#BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-#WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
-#OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
-#ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from this
+# software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: 'AWS::Serverless-2016-10-31'

--- a/iridium-to-twilio/index.js
+++ b/iridium-to-twilio/index.js
@@ -1,6 +1,9 @@
 /*
 
-Copyright 2017 Hadi Esiely
+Copyright 2017 Ewan Mellor, JD Zamifirescu
+
+Changes authored by Hadi Esiely:
+Copyright 2018 The Johns Hopkins University Applied Physics Laboratory LLC.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
Updated licensing to show changes made by Hadi Esiely as copy right of
the Johns Hopkins University Applied Physics Laboratory LLC. as required
and requested by the Johns Hopkins University Applied Physics Laboratory
LLC.

Project is still Open Source and BSD 3 as agreed with the Johns Hopkins
University Applied Physics Laboratory LLC.

Contributions by Ewan Mellor, JD Zamifrescu and Ron Widenfelt retain
their copyright.

Signed-off-by: h <1879553+hadesto@users.noreply.github.com>